### PR TITLE
RAG-25: Fix to run tests in-memory

### DIFF
--- a/test_config.py
+++ b/test_config.py
@@ -15,7 +15,7 @@ BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 ADMINS = frozenset(['youremail@yourdomain.com'])
 
 # Define the database we are working with
-SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(BASE_DIR, 'test.db')
+SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
 DATABASE_CONNECT_OPTIONS = {}
 
 # Application threads. A common general assumption is using 2 per available processor core - to handle incoming


### PR DESCRIPTION
### Issue
Fixes #25 

### Summary
Updated `test_config.py` to use in-memory test database.

### Testing
* Delete `test.db` database file
* Run all tests and ensure all pass.
* Verify that `test.db` file doesn't get re-created.