### PR TITLE
Created foundation entities for RAG dashboard. Implemented quick dashboard to unblock RAG-18 and RAG-19

### DIFF
--- a/app/RAG/controllers.py
+++ b/app/RAG/controllers.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timedelta
+from injector import inject
+from flask import Blueprint, request, render_template, flash, g, session, redirect, url_for
+from flask.ext.sqlalchemy import SQLAlchemy
+
+from app.RAG.models import Entity, Metric
+from app.users.models import User
+from app.users.decorators import requires_login
+
+__author__ = 'Frito'
+
+mod = Blueprint('rag', __name__, url_prefix='/rag')
+
+
+@mod.before_request
+@inject(db=SQLAlchemy)
+def before_request(db):
+    """
+    pull user's profile from the database before every request
+    :param db: SQLAlchemy database
+    """
+    g.user = None
+    if 'user_id' in session:
+        g.user = db.session.query(User).get(session['user_id'])
+
+
+@mod.route('/', methods=['GET', 'POST'])
+@requires_login
+@inject(db=SQLAlchemy)
+def home(db):
+    data = db.session.query(Entity).all()
+    if not data:
+        data = populate_test_data(db)
+
+    headers = []
+    for entity in data:
+        for metric in entity.metrics:
+            if metric.date_for not in headers:
+                headers.append(metric.date_for)
+    return render_template("rag/dashboard.html", user=g.user, entities=data, headers=headers)
+
+
+# Test data generation, should be deleted once data entry is available from the UI.
+def populate_test_data(db):
+    data = []
+    for i in range(1, 6):
+        entity = Entity()
+        entity.name = 'Entity %d' % (i)
+
+        for j in range(0, 8):
+            metric = Metric()
+            metric.date_for = datetime.utcnow().date() + timedelta(days=j*7)
+            metric.status = 'Amber'
+            entity.metrics.append(metric)
+
+        db.session.add(entity)
+        data.append(entity)
+
+    db.session.commit()
+    return data

--- a/app/RAG/models.py
+++ b/app/RAG/models.py
@@ -1,0 +1,37 @@
+from app import model_base
+from sqlalchemy import Column, Integer, String, ForeignKey, SmallInteger, Date
+from sqlalchemy.orm import relationship
+
+__author__ = 'Frito'
+
+
+class Entity(model_base.Base):
+
+    __tablename__ = 'rag_entity'
+    id = Column(Integer, primary_key=True)
+    name = Column(String(50), unique=True)
+    metrics = relationship("Metric")  # Not sure if we want to keep this mapping.
+
+    def __init__(self, name=None):
+        self.name = name
+
+    def __repr__(self):
+        return '<Entity %r>' % self.name
+
+
+class Metric(model_base.Base):
+
+    __tablename__ = 'rag_metric'
+    id = Column(Integer, primary_key=True)
+    entity_for = Column(Integer, ForeignKey('rag_entity.id'), nullable=False)
+    status = Column(SmallInteger, nullable=False)
+    date_for = Column(Date, nullable=False)
+    comments = Column(String(250))
+
+    # TODO: Do constant lookup for status
+
+    def __init__(self, name=None):
+        self.name = name
+
+    def __repr__(self):
+        return '<Metric %r>' % self.name

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -37,7 +37,7 @@
                 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                     <ul class="nav navbar-nav">
                         <li>
-                            <a href="#">About</a>
+                            <a href="{{ url_for('rag.home') }}">View</a>
                         </li>
                         <li>
                             <a href="#">Services</a>

--- a/app/templates/rag/dashboard.html
+++ b/app/templates/rag/dashboard.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block content %}
+    <table class="table table-striped table-bordered">
+    <thead>
+    <tr>
+        <td>Name</td>
+        {% for header in headers %}
+            <td>{{  header }}</td>
+        {% endfor %}
+    </tr>
+    </thead>
+    <tbody>
+    {% for entity in entities %}
+        <tr>
+            <td>{{ entity.name }}</td>
+            {% for metric in entity.metrics %}
+                <td>{{  metric.status }}</td>
+            {% endfor %}
+        </tr>
+    {% endfor %}
+    </tbody>
+    </table>
+{% endblock %}

--- a/run.py
+++ b/run.py
@@ -43,8 +43,10 @@ def build_app():
     # The from/import being here is okay since we do not want __init__ in our packages executing yet.
     from app.users.controllers import mod as users_module  # noqa: skips the pep8 violation here.
     from app.siteroot.controller import mod as siteroot_module  # noqa: skips the pep8 violation here.
+    from app.RAG.controllers import mod as rag_module  # noqa: skips the pep8 violation here.
     app.register_blueprint(users_module)
     app.register_blueprint(siteroot_module)
+    app.register_blueprint(rag_module)
 
     injector = Injector([ApplicationInitializer(app)])
     FlaskInjector(app=app, injector=injector)


### PR DESCRIPTION
### Issue
Fixes #17 

### Summary
* Created `models.py` with Entity and Metric entites
* Created controller and templates for the new RAG dashboard

### Testing
* Run available unit / integration tests. 
* Start app and poke around a bit
* Navigate to http://127.0.0.1:8000/rag/ to view the dashboard sample