### PR TITLE
removed recaptacha and redundant login from registration page

### DIFF
--- a/app/templates/users/register.html
+++ b/app/templates/users/register.html
@@ -8,10 +8,6 @@
     {{ render_field(form.password, class="input text") }}
     {{ render_field(form.confirm, class="input text") }}
     {{ render_field(form.accept_tos, class="input checkbox") }}
-    <label>ReCaptcha</label>
-    {{ form.recaptcha }}
     <input type="submit" value="Register" class="button green">
   </form>
-  <a href="{{ url_for('users.login') }}">Login</a>
 {% endblock %}
-<!--http://www.bootply.com/nJ2P2gi76B-->

--- a/app/users/controllers.py
+++ b/app/users/controllers.py
@@ -1,7 +1,7 @@
 from injector import Module, Injector, inject, singleton
 from flask import Blueprint, request, render_template, flash, g, session, redirect, url_for
 from flask.ext.sqlalchemy import SQLAlchemy
-from werkzeug import check_password_hash, generate_password_hash
+from werkzeug.security import check_password_hash, generate_password_hash
 
 from app.users.forms import RegisterForm, LoginForm
 from app.users.models import User

--- a/app/users/forms.py
+++ b/app/users/forms.py
@@ -1,4 +1,4 @@
-from flask.ext.wtf import Form, RecaptchaField
+from flask.ext.wtf import Form
 from wtforms import StringField, PasswordField, BooleanField
 from wtforms.validators import DataRequired, EqualTo, Email
 
@@ -16,4 +16,3 @@ class RegisterForm(Form):
     password = PasswordField('Password', [DataRequired()])
     confirm = PasswordField('Repeat Password', [DataRequired(), EqualTo('password', message='Passwords must match')])
     accept_tos = BooleanField('I accept the TOS', [DataRequired()])
-    recaptcha = RecaptchaField()


### PR DESCRIPTION
### Issue 
Fixes #27

### Summary
Removed redundant login link and recaptcha thingie from the *register user* page. Also fixed red squiggly on the user controller for werkzeug import.

### Testing
Open the register page via the top menu bar link. Verify that the Recaptcha interface is not present and there is only one login link on the page (redundant login after recaptcha removed.)